### PR TITLE
Update x86_64 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1.2.1"
-x86_64 = "0.14.1-beta"
+x86_64 = "0.14.3"


### PR DESCRIPTION
This PR updates `x86_64` crate to fix `const_fn feature has been removed` compilation error